### PR TITLE
Added  BSC PandaSwap Token, Bamboo, and Rhino

### DIFF
--- a/bsc.json
+++ b/bsc.json
@@ -604,6 +604,30 @@
 			"decimals": 18,
 			"chainId": 56,
 			"logoURI": "https://assets.coingecko.com/coins/images/11976/small/Cream.png?1596593418"
+		},
+		{
+			"name": "PandaSwap Token",
+			"address": "0x47DcC83a14aD53Ed1f13d3CaE8AA4115f07557C0",
+			"symbol": "PNDA",
+			"decimals": 18,
+			"chainId": 56,
+			"logoURI": "https://www.pandaswap.xyz/static/media/pnda-logo.afd82c21.png"
+		},
+		{
+			"name": "Rhino",
+			"address": "0xd2eca3cff5f09cfc9c425167d12f0a005fc97c8c",
+			"symbol": "RHINO",
+			"decimals": 9,
+			"chainId": 56,
+			"logoURI": "https://farms.pandaswap.xyz/rhino.png"
+		},
+		{
+			"name": "BambooBar",
+			"address": "0xef88e0d265ddc8f5e725a4fda1871f9fe21b11e2",
+			"symbol": "BAMBOO",
+			"decimals": 18,
+			"chainId": 56,
+			"logoURI": "https://farms.pandaswap.xyz/bamboo.png"
 		}
 	  ]
 	}


### PR DESCRIPTION
PandaSwap Token / PNDA
0x47DcC83a14aD53Ed1f13d3CaE8AA4115f07557C0",
18 Decimals
Logo: https://www.pandaswap.xyz/static/media/pnda-logo.afd82c21.png

Rhino / RHINO
0xd2eca3cff5f09cfc9c425167d12f0a005fc97c8c
9 Decimals
https://farms.pandaswap.xyz/rhino.png

BambooBar / BAMBOO
0xef88e0d265ddc8f5e725a4fda1871f9fe21b11e2
18 Decimals
https://farms.pandaswap.xyz/bamboo.png